### PR TITLE
fix warnings on the agamemnon

### DIFF
--- a/include/yacx/Device.hpp
+++ b/include/yacx/Device.hpp
@@ -25,10 +25,10 @@ class Device : JNIHandle {
   explicit Device(std::string name);
   //! Minor compute capability version number
   //! \return version number
-  [[nodiscard]] int minor() const { return m_minor; }
+  [[nodiscard]] int minor_version() const { return m_minor; }
   //! Major compute capability version number
   //! \return version number
-  [[nodiscard]] int major() const { return m_major; }
+  [[nodiscard]] int major_version() const { return m_major; }
   //! identifer string for the device
   //! \return identifer string
   std::string name() const { return m_name; }

--- a/include/yacx/Options.hpp
+++ b/include/yacx/Options.hpp
@@ -101,7 +101,7 @@ class GpuArchitecture {
               std::to_string(minor)) {}
 
   explicit GpuArchitecture(const yacx::Device &device)
-      : GpuArchitecture(device.major(), device.minor()) {}
+      : GpuArchitecture(device.major_version(), device.minor_version()) {}
 
   auto name() const { return "--gpu-architecture"; }
   auto &value() const { return m_arc; }


### PR DESCRIPTION
I changed `minor()` to `minor_version()` and `major()` to `major_version()`