### PR TITLE
#67

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           script: |
             cd /tmp/ci/$GITHUB_REPOSITORY/$COMMIT_SHA
             make -C build JNITestClasses
-            cp examples/kernels/* $JAVA_DIR
+            cp -R examples/kernels $JAVA_DIR
             pushd $JAVA_DIR
             java -Djava.library.path=../../ -jar src/junit-platform-console-standalone-1.5.2.jar --class-path . --scan-class-path
             popd

--- a/examples/java/ExampleBlockReduce.java
+++ b/examples/java/ExampleBlockReduce.java
@@ -24,7 +24,7 @@ public class ExampleBlockReduce {
         IntArg nArg = IntArg.create(arraySize);
 
         //Load kernelString
-        String kernelString = Utils.loadFile("block_reduce.cu");
+        String kernelString = Utils.loadFile("kernels/block_reduce.cu");
         //Create Program
         Program blockReduce = Program.create(kernelString, "deviceReduceKernel");
 

--- a/examples/java/ExampleFilter.java
+++ b/examples/java/ExampleFilter.java
@@ -24,7 +24,7 @@ public class ExampleFilter {
         nArg = IntArg.create(n);
 
         //Create Program
-        String kernelString = Utils.loadFile("filter_k.cu");
+        String kernelString = Utils.loadFile("kernels/filter_k.cu");
         Program filter = Program.create(kernelString, "filter_k");
 
         //Create compiled Kernel

--- a/examples/java/ExampleFilterBenchmark.java
+++ b/examples/java/ExampleFilterBenchmark.java
@@ -7,7 +7,7 @@ public class ExampleFilterBenchmark {
     	//Load Libary
     	Executor.loadLibary();
     	
-        String saxpy = Utils.loadFile("filter_k.cu");
+        String saxpy = Utils.loadFile("kernels/filter_k.cu");
         
         //Benchmark filter-Kernel
         System.out.println(Executor.benchmark(saxpy, "filter_k", Options.createOptions(), 10,

--- a/examples/java/ExampleGauss.java
+++ b/examples/java/ExampleGauss.java
@@ -1,0 +1,143 @@
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+public class ExampleGauss {
+//    void writePPM(Pixel *pixels, String filename, int width, int height) {
+//        std::ofstream outputFile(filename, std::ios::binary);
+//      
+//        // write header:
+//        outputFile << "P6\n" << width << " " << height << "\n255\n";
+//      
+//        outputFile.write(reinterpret_cast<const char *>(pixels),
+//                         sizeof(Pixel) * width * height);
+//    }
+//      
+      // Pointer returned must be explicitly freed!
+      PixelArray readPPM(String filename, int width, int height) {
+        
+      
+        // parse harder
+        // first line: P6\n
+        inputFile.ignore(2, '\n'); // ignore P6
+        // possible comments:
+        while (inputFile.peek() == '#') {
+          inputFile.ignore(1024, '\n');
+        } // skip comment
+        // next line: width_height\n
+        inputFile >> (*width);
+        inputFile.ignore(1, ' '); // ignore space
+        inputFile >> (*height);
+        inputFile.ignore(1, '\n'); // ignore newline
+        // possible comments:
+        while (inputFile.peek() == '#') {
+          inputFile.ignore(1024, '\n');
+        } // skip comment
+        // last header line: 255\n:
+        inputFile.ignore(3, '\n'); // ignore 255 and newline
+      
+        Pixel *data = new Pixel[(*width) * (*height)];
+        
+        inputFile.read(reinterpret_cast<char *>(data),
+                       sizeof(Pixel) * (*width) * (*height));
+      
+        return data;
+      }
+
+	static float[][] calculateWeights(int size) {
+		float[][] weights = new float[size][size];
+		
+        float sigma = 1.0f;
+        float r, s = 2.0f * sigma * sigma;
+      
+        // sum is for normalization
+        float sum = 0.0f;
+      
+        // generate weights for 5x5 kernel
+        for (int x = -2; x <= 2; x++) {
+          for (int y = -2; y <= 2; y++) {
+            r = x * x + y * y;
+            weights[x + 2][y + 2] = (float) (Math.exp(-(r / s)) / (Math.PI * s));
+            sum += weights[x + 2][y + 2];
+          }
+        }
+      
+        // normalize the weights
+        for (int i = 0; i < 5; ++i) {
+          for (int j = 0; j < 5; ++j) {
+            weights[i][j] /= sum;
+          }
+        }
+        
+        return weights;
+    }
+
+	public static void main(String[] args) {
+		// Load Libary
+		Executor.loadLibary();
+
+		// Testdata
+		final String inputFile = "lenna.ppm";
+		final String outputFile = "output.ppm";
+		
+		float[][] weigths = calculateWeights(5);
+		int width;
+		int height;
+		
+		PixelArray image = 
+
+		// Initialize Arguments
+		KernelArg aArg, nArg, xArg, yArg;
+		FloatArg outArg;
+		aArg = FloatArg.createValue(a);
+		xArg = FloatArg.create(x);
+		yArg = FloatArg.create(y);
+		outArg = FloatArg.createOutput(n);
+		nArg = IntArg.createValue(n);
+
+		// Create Program
+		String kernelString = Utils.loadFile("saxpy.cu");
+		Program saxpy = Program.create(kernelString, "saxpy");
+
+		// Create compiled Kernel
+		Kernel saxpyKernel = saxpy.compile();
+
+		// Compile and launch Kernel
+		KernelTime executionTime = saxpyKernel.launch(numThreads, numBlocks, aArg, xArg, yArg, outArg, nArg);
+
+		// Get Result
+		float[] out = outArg.asFloatArray();
+
+		// Print Result
+		System.out.println("\nsaxpy-Kernel sucessfully launched:");
+		System.out.println(executionTime);
+		System.out.println("\nInput a: " + a);
+		System.out.println("Input x: " + Arrays.toString(x));
+		System.out.println("Input y: " + Arrays.toString(y));
+		System.out.println("Result:  " + Arrays.toString(out));
+	}
+	
+	static class PixelArray {
+		private byte[] pixel;
+		
+		public PixelArray(int length) {
+			pixel = new byte[length*3];
+		}
+		
+		public void setPixel(int i, byte r, byte b, byte g) {
+			int j = i*3;
+			pixel[j] = r;
+			pixel[j+1] = b;
+			pixel[j+2] = g;
+		}
+		
+		public byte[] asByteArray() {
+			return pixel;
+		}
+	}
+	
+	
+	
+	
+}
+

--- a/examples/java/ExampleGauss.java
+++ b/examples/java/ExampleGauss.java
@@ -3,15 +3,15 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 
 public class ExampleGauss {
 	static void writePPM(PixelArray pixels, String filename) throws IOException {
 		try (FileOutputStream os = new FileOutputStream(new File(filename));
-				BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(os))){
+				BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(os))) {
 			
 			//Writer Header
 			writer.write("P6\n");
@@ -30,8 +30,10 @@ public class ExampleGauss {
 	}
 	
     static PixelArray readPPM(String filename) throws IOException {
-    	try (InputStream is = new FileInputStream(new File(filename));
-          	  BufferedReader reader = new BufferedReader(new InputStreamReader(is));) {
+    	File file = new File(filename);
+    	
+    	try (InputStream is = new FileInputStream(file);
+          	  BufferedReader reader = new BufferedReader(new FileReader(file))) {
     		
             //Skip first 3 Bytes (Header)
             reader.skip(3);
@@ -48,10 +50,12 @@ public class ExampleGauss {
             while ((line = reader.readLine()).startsWith("#"));
             
             //Last header line
-            assert(line.equals("255\n"));
+            assert(line.equals("255"));
             
             //Read pixels
             PixelArray pixels = new PixelArray(width, height);
+            
+            is.skip(file.length()-pixels.getPixel().length);
             
             is.read(pixels.getPixel());
             
@@ -60,7 +64,7 @@ public class ExampleGauss {
     }
 
 	static float[] calculateWeights(int size) {
-		float[] weights = new float[size];
+		float[] weights = new float[size*size];
 		
         float sigma = 1.0f;
         float r, s = 2.0f * sigma * sigma;
@@ -92,7 +96,7 @@ public class ExampleGauss {
 		Executor.loadLibary();
 
 		// Testdata
-		final String inputFile = "lenna.ppm";
+		final String inputFile = "kernels/lena.ppm";
 		final String outputFile = "output.ppm";
 		
 		float[] weigths = calculateWeights(5);

--- a/examples/java/ExampleSaxpy.java
+++ b/examples/java/ExampleSaxpy.java
@@ -29,7 +29,7 @@ public class ExampleSaxpy {
         nArg = IntArg.createValue(n);
 
         //Create Program
-        String kernelString = Utils.loadFile("saxpy.cu");
+        String kernelString = Utils.loadFile("kernels/saxpy.cu");
         Program saxpy = Program.create(kernelString, "saxpy");
 
         //Create compiled Kernel

--- a/examples/java/ExampleSaxpyBenchmark.java
+++ b/examples/java/ExampleSaxpyBenchmark.java
@@ -7,7 +7,7 @@ public class ExampleSaxpyBenchmark {
     	//Load Libary
     	Executor.loadLibary();
     	
-        String saxpy = Utils.loadFile("saxpy.cu");
+        String saxpy = Utils.loadFile("kernels/saxpy.cu");
         
         //Benchmark saxpy-Kernel
         System.out.println(Executor.benchmark(saxpy, "saxpy", Options.createOptions(), 10,

--- a/examples/scala/ExampleFilter.scala
+++ b/examples/scala/ExampleFilter.scala
@@ -21,7 +21,7 @@ object ExampleFilter {
         val nArg = IntArg.createValue(n)
 
         //Create Program
-        val kernelString = Utils.loadFile("filter_k.cu")
+        val kernelString = Utils.loadFile("kernels/filter_k.cu")
         val filter = Program.create(kernelString, "filter_k")
 
         //Create compiled Kernel

--- a/examples/scala/ExampleFilterBenchmark.scala
+++ b/examples/scala/ExampleFilterBenchmark.scala
@@ -5,7 +5,7 @@ object ExampleFilterBenchmark {
     	//Load Libary
     	Executor.loadLibary()
     	
-      val saxpy = Utils.loadFile("filter_k.cu")
+      val saxpy = Utils.loadFile("kernels/filter_k.cu")
         
       //Benchmark filter-Kernel
       println(Executor.benchmark(saxpy, "filter_k", Options.createOptions(), 10,

--- a/examples/scala/ExampleGauss.scala
+++ b/examples/scala/ExampleGauss.scala
@@ -1,0 +1,109 @@
+object ExampleGauss {
+    def writePPM(Pixel *pixels, const char *filename, int width, int height) : Unit {
+        std::ofstream outputFile(filename, std::ios::binary);
+      
+        // write header:
+        outputFile << "P6\n" << width << " " << height << "\n255\n";
+      
+        outputFile.write(reinterpret_cast<const char *>(pixels),
+                         sizeof(Pixel) * width * height);
+    }
+      
+      // Pointer returned must be explicitly freed!
+      Pixel *readPPM(const char *filename, int *width, int *height) {
+        std::ifstream inputFile(filename, std::ios::binary);
+      
+        // parse harder
+        // first line: P6\n
+        inputFile.ignore(2, '\n'); // ignore P6
+        // possible comments:
+        while (inputFile.peek() == '#') {
+          inputFile.ignore(1024, '\n');
+        } // skip comment
+        // next line: width_height\n
+        inputFile >> (*width);
+        inputFile.ignore(1, ' '); // ignore space
+        inputFile >> (*height);
+        inputFile.ignore(1, '\n'); // ignore newline
+        // possible comments:
+        while (inputFile.peek() == '#') {
+          inputFile.ignore(1024, '\n');
+        } // skip comment
+        // last header line: 255\n:
+        inputFile.ignore(3, '\n'); // ignore 255 and newline
+      
+        Pixel *data = new Pixel[(*width) * (*height)];
+        
+        inputFile.read(reinterpret_cast<char *>(data),
+                       sizeof(Pixel) * (*width) * (*height));
+      
+        return data;
+      }
+      
+      void calculateWeights(float weights[5][5]) {
+        float sigma = 1.0;
+        float r, s = 2.0 * sigma * sigma;
+      
+        // sum is for normalization
+        float sum = 0.0;
+      
+        // generate weights for 5x5 kernel
+        for (int x = -2; x <= 2; x++) {
+          for (int y = -2; y <= 2; y++) {
+            r = x * x + y * y;
+            weights[x + 2][y + 2] = exp(-(r / s)) / (M_PI * s);
+            sum += weights[x + 2][y + 2];
+          }
+        }
+      
+        // normalize the weights
+        for (int i = 0; i < 5; ++i) {
+          for (int j = 0; j < 5; ++j) {
+            weights[i][j] /= sum;
+          }
+        }
+      }
+
+    def main(args: Array[String]) : Unit = {
+        //Load Libary
+        Executor.loadLibary()
+
+        //Testdata
+        val numThreads = 16
+        val numBlocks = 1
+
+        val n = 16
+        val in = new Array[Int](n)
+
+        for (i <- 0 until n){
+            in(i) = i
+        }
+
+        //Initialize Arguments
+        val srcArg = IntArg.create(in: _*)
+        val outArg = IntArg.createOutput(n/2)
+        val counterArg = IntArg.create(Array[Int](0), true)
+        val nArg = IntArg.createValue(n)
+
+        //Create Program
+        val kernelString = Utils.loadFile("filter_k.cu")
+        val filter = Program.create(kernelString, "filter_k")
+
+        //Create compiled Kernel
+        val filterKernel = filter.compile()
+
+        //Launch Kernel
+        val executionTime = filterKernel.launch(numThreads, numBlocks, outArg, counterArg, srcArg, nArg)
+
+        //Get Result
+        val out = outArg.asIntArray()
+        val counter = counterArg.asIntArray()(0)
+
+        //Print Result
+        println("\nfilter-Kernel sucessfully launched:");
+        println(executionTime);
+        println("\nInput:          [" + in.mkString(", ") + "]");
+        println("Result counter: " + counter);
+        println("Result:         [" + out.mkString(", ") + "]");
+  }
+}

--- a/examples/scala/ExampleGauss.scala
+++ b/examples/scala/ExampleGauss.scala
@@ -1,109 +1,173 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+
 object ExampleGauss {
-    def writePPM(Pixel *pixels, const char *filename, int width, int height) : Unit {
-        std::ofstream outputFile(filename, std::ios::binary);
-      
-        // write header:
-        outputFile << "P6\n" << width << " " << height << "\n255\n";
-      
-        outputFile.write(reinterpret_cast<const char *>(pixels),
-                         sizeof(Pixel) * width * height);
-    }
-      
-      // Pointer returned must be explicitly freed!
-      Pixel *readPPM(const char *filename, int *width, int *height) {
-        std::ifstream inputFile(filename, std::ios::binary);
-      
-        // parse harder
-        // first line: P6\n
-        inputFile.ignore(2, '\n'); // ignore P6
-        // possible comments:
-        while (inputFile.peek() == '#') {
-          inputFile.ignore(1024, '\n');
-        } // skip comment
-        // next line: width_height\n
-        inputFile >> (*width);
-        inputFile.ignore(1, ' '); // ignore space
-        inputFile >> (*height);
-        inputFile.ignore(1, '\n'); // ignore newline
-        // possible comments:
-        while (inputFile.peek() == '#') {
-          inputFile.ignore(1024, '\n');
-        } // skip comment
-        // last header line: 255\n:
-        inputFile.ignore(3, '\n'); // ignore 255 and newline
-      
-        Pixel *data = new Pixel[(*width) * (*height)];
+  	def writePPM(pixels: PixelArray, filename: String) : Unit = {
+    		var os : FileOutputStream = null
+    		var writer : BufferedWriter = null
+    				
+        try {
+    			os = new FileOutputStream(new File(filename))
+    		  writer = new BufferedWriter(new OutputStreamWriter(os))
+    		  
+    			//Writer Header
+    			writer.write("P6\n")
+    			
+    			//Write width and height
+    			writer.write("" + pixels.getWidth() + " " + pixels.getHeight() + "\n")
+    			
+    			//Write header-end
+    			writer.write("255\n")
+    			
+    			writer.flush()
+    			
+    			//Writer Pixels
+    			os.write(pixels.getPixel())
+    		} finally {
+    	    if (os != null)
+    	        os.close()
+    	    if (writer != null)
+    	        writer.close()
+    	}
+  	}
+	
+    def readPPM(filename: String) : PixelArray = {
+        val file = new File(filename)
+        var is : FileInputStream = null
+        var reader : BufferedReader = null
         
-        inputFile.read(reinterpret_cast<char *>(data),
-                       sizeof(Pixel) * (*width) * (*height));
-      
-        return data;
-      }
-      
-      void calculateWeights(float weights[5][5]) {
-        float sigma = 1.0;
-        float r, s = 2.0 * sigma * sigma;
-      
+        try {
+            is = new FileInputStream(file)
+            reader = new BufferedReader(new FileReader(file))
+              
+            //Skip first 3 Bytes (Header)
+            reader.skip(3)
+            
+            //Ignore comments
+            var line : String = null
+            do {
+                line = reader.readLine()
+            } while (line.startsWith("#"));
+            
+            //Read width and height
+            val width = Integer.parseInt(line.substring(0, line.indexOf(" ")))
+            val height = Integer.parseInt(line.substring(line.indexOf(" ")+1))
+            
+            //Ignore comments
+            do {
+                line = reader.readLine()
+            } while (line.startsWith("#"));
+            
+            //Last header line
+            assert(line.equals("255"))
+            
+            //Read pixels
+            val pixels = new PixelArray(width, height)
+            
+            is.skip(file.length()-pixels.getPixel().length);
+            
+            is.read(pixels.getPixel())
+            
+            return pixels
+    	} finally {
+    	    if (is != null)
+    	        is.close()
+    	    if (reader != null)
+    	        reader.close()
+    	}
+    }
+
+  	def calculateWeights(size: Int) : Array[Float] = {
+  		  val weights = new Array[Float](size*size)
+  		
+        val sigma = 1.0f
+        var r, s = 2.0f * sigma * sigma
+        
         // sum is for normalization
-        float sum = 0.0;
-      
+        var sum = 0.0f
+        
         // generate weights for 5x5 kernel
-        for (int x = -2; x <= 2; x++) {
-          for (int y = -2; y <= 2; y++) {
-            r = x * x + y * y;
-            weights[x + 2][y + 2] = exp(-(r / s)) / (M_PI * s);
-            sum += weights[x + 2][y + 2];
+        for (x <- -size/2 until size/2 + 1) {
+          for (y <- -size/2 until size/2 + 1) {
+            r = x * x + y * y
+            weights((x + 2)*size + y + 2) = ((Math.exp(-(r / s)) / (Math.PI * s))).toFloat
+            sum += weights((x + 2)*size + y + 2)
           }
         }
-      
+        
         // normalize the weights
-        for (int i = 0; i < 5; ++i) {
-          for (int j = 0; j < 5; ++j) {
-            weights[i][j] /= sum;
+        for (i <- 0 until size) {
+          for (j <- 0 until size) {
+            weights(i*size + j) /= sum
           }
         }
-      }
+          
+        return weights
+    }
 
-    def main(args: Array[String]) : Unit = {
-        //Load Libary
-        Executor.loadLibary()
-
-        //Testdata
-        val numThreads = 16
-        val numBlocks = 1
-
-        val n = 16
-        val in = new Array[Int](n)
-
-        for (i <- 0 until n){
-            in(i) = i
-        }
-
-        //Initialize Arguments
-        val srcArg = IntArg.create(in: _*)
-        val outArg = IntArg.createOutput(n/2)
-        val counterArg = IntArg.create(Array[Int](0), true)
-        val nArg = IntArg.createValue(n)
-
-        //Create Program
-        val kernelString = Utils.loadFile("filter_k.cu")
-        val filter = Program.create(kernelString, "filter_k")
-
-        //Create compiled Kernel
-        val filterKernel = filter.compile()
-
-        //Launch Kernel
-        val executionTime = filterKernel.launch(numThreads, numBlocks, outArg, counterArg, srcArg, nArg)
-
-        //Get Result
-        val out = outArg.asIntArray()
-        val counter = counterArg.asIntArray()(0)
-
-        //Print Result
-        println("\nfilter-Kernel sucessfully launched:");
-        println(executionTime);
-        println("\nInput:          [" + in.mkString(", ") + "]");
-        println("Result counter: " + counter);
-        println("Result:         [" + out.mkString(", ") + "]");
-  }
-}
+  	def main(args: Array[String]) : Unit = {
+    		// Load Libary
+    		Executor.loadLibary()
+    
+    		// Testdata
+    		val inputFile = "kernels/lena.ppm"
+    		val outputFile = "output.ppm"
+    		
+    		val weigths = calculateWeights(5)
+    		
+    		val image = readPPM(inputFile)
+    		val width = image.getWidth()
+    		val height = image.getHeight()
+    
+    		// Initialize Arguments
+    		val weightsArg = FloatArg.create(weigths: _*)
+    		val widthArg = IntArg.createValue(width)
+    		val heightArg = IntArg.createValue(height)
+    		val imageArg = ByteArg.create(image.getPixel(), true)
+    
+    		//Create Program
+    		val kernelString = Utils.loadFile("gauss.cu")
+    
+    		//Compile and launch Kernel
+    		val executionTime = Executor.launch(kernelString, "gaussFilterKernel", width, height, 1,
+    				1, 1, 1, imageArg, weightsArg, widthArg, heightArg)
+    
+    		//Get Result
+    		val imageFiltered = new PixelArray(width, height, imageArg.asByteArray())
+    		
+    		println("\ngauss-Kernel sucessfully launched:")
+        println(executionTime)
+        println("\nInputfile: " + inputFile)
+        println("Outputfile: " + outputFile)
+    
+    		//Write Result
+    		writePPM(imageFiltered, outputFile)
+  	}
+  	
+  	class PixelArray(width: Int, height: Int, pixel: Array[Byte]) {
+  	    
+  	    def this(width: Int, height: Int) {
+  	      this(width, height, new Array[Byte](width*height*3))
+  	    }
+  	    
+    		def getPixel() : Array[Byte] = {
+    		    return pixel
+    		}
+    
+    		def getWidth() : Int = {
+    			  return width
+    		}
+    
+    		def getHeight() : Int = {
+    			  return height
+    		}
+    }
+} 	
+ 

--- a/examples/scala/ExampleSaxpy.scala
+++ b/examples/scala/ExampleSaxpy.scala
@@ -24,7 +24,7 @@ object ExampleSaxpy {
         val nArg = IntArg.createValue(n)
 
         //Create Program
-        val kernelString = Utils.loadFile("saxpy.cu")
+        val kernelString = Utils.loadFile("kernels/saxpy.cu")
         val saxpy = Program.create(kernelString, "saxpy")
 
         //Create compiled Kernel

--- a/examples/scala/ExampleSaxpyBenchmark.scala
+++ b/examples/scala/ExampleSaxpyBenchmark.scala
@@ -5,7 +5,7 @@ object ExampleSaxpyBenchmark {
     	//Load Libary
     	Executor.loadLibary()
     	
-      val saxpy = Utils.loadFile("saxpy.cu")
+      val saxpy = Utils.loadFile("kernels/saxpy.cu")
         
       //Benchmark saxpy-Kernel
       println(Executor.benchmark(saxpy, "saxpy", Options.createOptions(), 10,

--- a/src/java/Executor.java
+++ b/src/java/Executor.java
@@ -8,15 +8,15 @@ public class Executor {
     }
     
     public static KernelTime launch(String kernelName, int grid, int block, KernelArg ...args) throws IOException {
-    	return launch(Utils.loadFile(kernelName + ".cu"), kernelName, grid, block, args);
+    	return launch(Utils.loadFile("kernels/" + kernelName + ".cu"), kernelName, grid, block, args);
     }
     
     public static KernelTime launch(String kernelName, Options options, int grid, int block, KernelArg ...args) throws IOException {
-    	return launch(Utils.loadFile(kernelName + ".cu"), kernelName, options, grid, block, args);
+    	return launch(Utils.loadFile("kernels/" + kernelName + ".cu"), kernelName, options, grid, block, args);
     }
 
     public static KernelTime launch(String kernelName, Options options, String deviceName, int grid, int block, KernelArg ...args) throws IOException {
-        return launch(Utils.loadFile(kernelName + ".cu"), kernelName, options, deviceName, grid, block, args);
+        return launch(Utils.loadFile("kernels/" + kernelName + ".cu"), kernelName, options, deviceName, grid, block, args);
     }
     
     public static KernelTime launch(String kernelString, String kernelName, int grid, int block, KernelArg ...args) {
@@ -32,15 +32,15 @@ public class Executor {
     }
     
     public static KernelTime launch(String kernelName, int grid0, int grid1, int grid2, int block0, int block1, int block2, KernelArg ...args) throws IOException {
-    	return launch(Utils.loadFile(kernelName + ".cu"), kernelName, grid0, grid1, grid2, block0, block1, block2, args);
+    	return launch(Utils.loadFile("kernels/" + kernelName + ".cu"), kernelName, grid0, grid1, grid2, block0, block1, block2, args);
     }
     
     public static KernelTime launch(String kernelName, Options options, int grid0, int grid1, int grid2, int block0, int block1, int block2, KernelArg ...args) throws IOException {
-    	return launch(Utils.loadFile(kernelName + ".cu"), kernelName, options, grid0, grid1, grid2, block0, block1, block2, args);
+    	return launch(Utils.loadFile("kernels/" + kernelName + ".cu"), kernelName, options, grid0, grid1, grid2, block0, block1, block2, args);
     }
 
     public static KernelTime launch(String kernelName, Options options, String deviceName, int grid0, int grid1, int grid2, int block0, int block1, int block2, KernelArg ...args) throws IOException {
-      	return launch(Utils.loadFile(kernelName + ".cu"), kernelName, options, deviceName, grid0, grid1, grid2, block0, block1, block2, args);
+      	return launch(Utils.loadFile("kernels/" + kernelName + ".cu"), kernelName, options, deviceName, grid0, grid1, grid2, block0, block1, block2, args);
     }
     
     public static KernelTime launch(String kernelString, String kernelName, int grid0, int grid1, int grid2, int block0, int block1, int block2, KernelArg ...args) {

--- a/test/java/TestJNI.java
+++ b/test/java/TestJNI.java
@@ -14,8 +14,8 @@ public class TestJNI {
 	@BeforeAll
 	static void loadKernelStrings() throws IOException {
 		//Load Saxpy and Filter-Kernel as String
-		saxpy = Utils.loadFile("saxpy.cu");
-		filterk = Utils.loadFile("filter_k.cu");
+		saxpy = Utils.loadFile("kernels/saxpy.cu");
+		filterk = Utils.loadFile("kernels/filter_k.cu");
 	}
 	
 	@BeforeAll

--- a/test/java/TestUtils.java
+++ b/test/java/TestUtils.java
@@ -16,6 +16,6 @@ public class TestUtils {
 
 	@Test
 	void loadFile() throws IOException {
-		assertEquals(saxpy, Utils.loadFile("saxpy.cu"));
+		assertEquals(saxpy, Utils.loadFile("kernels/saxpy.cu"));
 	}
 }

--- a/yacx.sh
+++ b/yacx.sh
@@ -6,7 +6,7 @@ JAVA_BIN="${BUILD_DIR}/java/bin"
 
 buildj() {
   mkdir -p $JAVA_BIN
-  cp examples/kernels/* $JAVA_BIN
+  cp -R examples/kernels $JAVA_BIN
   cp examples/java/*.java $JAVA_BIN
 
   pushd $BUILD_DIR


### PR DESCRIPTION
Gauss-Beispiel für Java und Scala gemacht
Das benutzt structs, wobei man in java einfach ein Byte-Array benutzen kann
Falls man halt benutzerdefinierte Datenstrukturen nutzen will (in Java), läufts darauf hinaus es als Byte-Array zu implementieren und evtl. je nach Datenstruktur noch eine eigene Wrapper-Klasse zu machen
**Edit:** Die tests laufen nicht durch wegen der Pfadanpassung der kernels für Java. Das yml-File wird mit diesem Request auch korrigiert