### PR TITLE
[WIP] Context class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 
 add_definitions(-DNVRTC_GET_TYPE_NAME=1)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-Wall -Dcurrent_log_level=loglevel::DEBUG)
+endif()
+
 
 include_directories(include)
 include_directories(include/yacx)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_definitions(-Wall -Dcurrent_log_level=loglevel::INFO)
-endif()
-
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/kernels/gauss.h
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/bin/kernels)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/kernels/gauss.cu

--- a/examples/example_saxpy.cpp
+++ b/examples/example_saxpy.cpp
@@ -5,7 +5,7 @@
 #define NUM_BLOCKS 1024
 
 using yacx::Source, yacx::KernelArg, yacx::KernelTime, yacx::Kernel,
-    yacx::Device, yacx::load, yacx::type_of;
+    yacx::Device, yacx::Context, yacx::load, yacx::type_of;
 
 int main() {
   const float DELTA{0.01f};

--- a/examples/example_saxpy.cpp
+++ b/examples/example_saxpy.cpp
@@ -21,6 +21,7 @@ int main() {
 
   try {
     Device dev;
+    Context ctx{dev};
     Source source{
         "extern \"C\" __global__\n"
         "void saxpy(float a, float *x, float *y, float *out, size_t n) {\n"
@@ -48,7 +49,7 @@ int main() {
     time = source.program("saxpy")
                .compile()
                .configure(grid, block)
-               .launch(args, dev);
+               .launch(args, ctx);
 
     std::cout << "Theoretical Bandwith:        "
               << yacx::theoretical_bandwidth(dev) << " GB/s\n";

--- a/include/yacx/Context.hpp
+++ b/include/yacx/Context.hpp
@@ -12,10 +12,11 @@ class Context : JNIHandle {
   */
  public:
   Context(Device device = Device());
-  [[nodiscard]] CUcontext get() { return m_context }
+  ~Context();
+  [[nodiscard]] CUcontext get() { return m_context; }
 
  private:
   CUcontext m_context;
-}
+};
 
 } // namespace yacx

--- a/include/yacx/Context.hpp
+++ b/include/yacx/Context.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Device.hpp"
+#include <cuda.h>
+
+namespace yacx {
+
+class Context : JNIHandle {
+  /*!
+   \class Context Context.hpp
+   \brief Class to manage the current CUDA context
+  */
+ public:
+  Context(Device device = Device());
+  [[nodiscard]] CUcontext get() { return m_context }
+
+ private:
+  CUcontext m_context;
+}
+
+} // namespace yacx

--- a/include/yacx/Kernel.hpp
+++ b/include/yacx/Kernel.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Device.hpp"
+#include "Context.hpp"
 #include "JNIHandle.hpp"
 #include "KernelArgs.hpp"
 #include "KernelTime.hpp"
@@ -33,15 +33,15 @@ class Kernel : JNIHandle {
   Kernel &configure(dim3 grid, dim3 block);
   //!
   //! \param kernel_args
+  //! \param context
   //! \return KernelTime
-  KernelTime launch(KernelArgs args, Device device = Device());
+  KernelTime launch(KernelArgs args, Context context = Context());
 
  private:
   std::shared_ptr<char[]> m_ptx;
   std::string m_demangled_name;
 
   dim3 m_grid, m_block;
-  CUcontext m_context;
   CUmodule m_module;
   CUfunction m_kernel;
 };

--- a/include/yacx/main.hpp
+++ b/include/yacx/main.hpp
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "yacx/Context.hpp"
 #include "yacx/Device.hpp"
 #include "yacx/Exception.hpp"
 #include "yacx/Headers.hpp"

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1,0 +1,18 @@
+#include <yacx/Context.hpp>
+#include <yacx/Exception.hpp>
+#include <yacx/Logger.hpp>
+
+using yacx::Context, yacx::loglevel;
+
+Context::Context(Device device) {
+  logger(loglevel::DEBUG) << "create context for device " << device.name();
+  CUDA_SAFE_CALL(cuCtxCreate(&m_context, 0, device.get()));
+}
+
+~Context::Context {
+  logger(loglevel::DEBUG) << "destroying context";
+  CUresult result = cuCtxDestroy(m_context);
+  if (result != CUDA_SUCCESS) {
+    // error handling
+  }
+}

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -7,12 +7,16 @@ using yacx::Context, yacx::loglevel;
 Context::Context(Device device) {
   logger(loglevel::DEBUG) << "create context for device " << device.name();
   CUDA_SAFE_CALL(cuCtxCreate(&m_context, 0, device.get()));
+
+  unsigned int version;
+  CUDA_SAFE_CALL(cuCtxGetApiVersion(m_context, &version));
+  logger(loglevel::DEBUG1) << "context API version: " << version;
 }
 
-~Context::Context {
+Context::~Context() {
   logger(loglevel::DEBUG) << "destroying context";
   CUresult result = cuCtxDestroy(m_context);
   if (result != CUDA_SUCCESS) {
-    // error handling
+    logger(loglevel::ERROR) << yacx::detail::whichError(result);
   }
 }

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -26,7 +26,7 @@ KernelTime Kernel::launch(KernelArgs args, Context context) {
   cudaEvent_t start, launch, finish, stop;
 
   logger(loglevel::DEBUG) << "set context";
-  CUDA_SAFEL_CALL(cuCtxSetCurrent(context.get()));
+  CUDA_SAFE_CALL(cuCtxSetCurrent(context.get()));
 
   CUDA_SAFE_CALL(
       cuEventCreate(&start, CU_EVENT_DEFAULT)); // start of Kernel launch


### PR DESCRIPTION
creates a Context class  for handling the CUDA context that can be used as an argument for launching.

```c++
Device dev;
Context ctx{dev};
source.program("saxpy")
    .compile()
    .configure(grid, block)
    .launch(args, ctx);
```

If no device is given to context it will just use the first device it will find
and if no context is given to launch it will just create a context with the first device.

### Questions:
  1. how to change context
  - CUcontext are put on a stack and can be popped and pushed, e.g. [`cuCtxPopCurrent`](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1g2fac188026a062d92e91a8687d0a7902)
  - [`cuCtxSetCurrent`](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html#group__CUDA__CTX_1gbe562ee6258b4fcc272ca6478ca2a2) (current approach) but this also uses the stack not sure what exactly happens here
  2. is [primary context ](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__PRIMARY__CTX.html#group__CUDA__PRIMARY__CTX)what you would use with only one context?
  3. what is the usage counter mentioned for CUcontext

### Missing/Bugs:
  - [ ] when trying to destroy the context the context points to random garbage resoluting in either just cuda errors which can be ignored (but shouldn't) or in segfaults, since it addresses who knows what
  - [ ] JNI
  - [ ] tests
  - [ ] change examples
    - [x] saxpy
    - [ ] program
    - [ ] matrix
