### PR TITLE
[WIP] header explicitly add content

### DIFF
--- a/examples/example_gauss.cpp
+++ b/examples/example_gauss.cpp
@@ -90,9 +90,7 @@ int main(int argc, char **argv) {
   Pixel *image = readPPM(inFilename, &width, &height);
 
   try {
-    Headers headers;
-    headers.insert(Header{"kernels/gauss.h"});
-    Source source{load("kernels/gauss.cu"), headers};
+    Source source{load("examples/kernels/gauss.cu")};
 
     size_t size_pixel = height * width * sizeof(Pixel);
     size_t size_weights = 5 * 5 * sizeof(float);

--- a/examples/example_matrix_multiply.cpp
+++ b/examples/example_matrix_multiply.cpp
@@ -97,7 +97,7 @@ int main() {
 
     // Set kernel string and compile options
 
-    Source source{load("kernels/matrixMult.cu")};
+    Source source{load("examples/kernels/matrixMult.cu")};
     Options options;
     options.insert("--std", "c++14");
     options.insert("--device-debug");

--- a/examples/kernels/device_reduce.cu
+++ b/examples/kernels/device_reduce.cu
@@ -1,4 +1,4 @@
-#include "kernels/block_reduce.h"
+#include "examples/kernels/block_reduce.h"
 
 #include <algorithm>
 

--- a/examples/kernels/gauss.cu
+++ b/examples/kernels/gauss.cu
@@ -1,4 +1,4 @@
-#include "kernels/gauss.h"
+#include "examples/kernels/gauss.h"
 
 extern "C" __global__ void gaussFilterKernel(Pixel *image,
                                              float weight[5][5],

--- a/include/yacx/Headers.hpp
+++ b/include/yacx/Headers.hpp
@@ -12,22 +12,22 @@ namespace yacx {
 /*!
   \class Header Headers.hpp
   \brief Class to help import header files for Source
+  this is only interesting if the headers are not available at runtime
 */
 class Header {
  public:
   //!
-  //! \param path relative path to header file
-  explicit Header(const std::string &path)
-      : _path{path}, _content{load(path)} {}
-  const char *name() const { return _path.c_str(); }
-  size_t length() const { return _path.size(); }
+  //! \param name relative name to header file
+  explicit Header(const std::string &name,std::string const &content)
+      : _name{name}, _content{content} {}
+  const char *name() const { return _name.c_str(); }
   //!
   //! \return c-style string of header content
   const char *content() const { return _content.c_str(); }
 
  private:
-  std::string _path{};
   std::string _content{};
+  std::string _name{};
 };
 
 //! checks if type is Header or can be casted to Header
@@ -35,9 +35,11 @@ class Header {
 template <typename T>
 struct is_header
     : public std::disjunction<
-          std::is_same<char *, typename std::decay<T>::type>,
-          std::is_same<const char *, typename std::decay<T>::type>,
-          std::is_same<std::string, typename std::decay<T>::type>,
+          std::is_same<std::pair<std::string, char>, typename std::decay<T>::type>,
+          std::is_same<std::pair<std::string, const char *>, typename std::decay<T>::type>,
+          std::is_same<std::pair<char, std::string>, typename std::decay<T>::type>,
+          std::is_same<std::pair<const char *, std::string>, typename std::decay<T>::type>,
+          std::is_same<std::pair<std::string, std::string>, typename std::decay<T>::type>,
           std::is_same<yacx::Header, typename std::decay<T>::type>> {};
 
 class Headers : JNIHandle {
@@ -52,17 +54,17 @@ class Headers : JNIHandle {
   //! constructs Headers with Header
   //! \param header
   explicit Headers(const Header &header);
-  //! constructs Headers with path to header file
-  //! \param path path to header file
-  explicit Headers(const std::string &path);
+  //! constructs Headers with name to header file
+  //! \param name name to header file
+  explicit Headers(const std::string &name);
   //! constructs a header from a header vector
   //! \param headers
   explicit Headers(std::vector<Header> headers);
-  //! constructs Headers with a multiple Header or paths to header files
+  //! constructs Headers with a multiple Header or names to header files
   //! \tparam T Header, std::string or char[]
   //! \tparam TS Header, std::string or char[]
-  //! \param arg Header or Path to header file
-  //! \param args  Header or Path to header file
+  //! \param arg Header or name to header file
+  //! \param args  Header or name to header file
   template <typename T, typename... TS>
   Headers(const T &arg, const TS &... args);
   //!
@@ -75,8 +77,8 @@ class Headers : JNIHandle {
   //! \return number of header files
   size_t numHeaders() const { return m_headers.size(); }
   //! inserts Header
-  //! \param path path to header file
-  void insert(std::string const &path) { m_headers.push_back(Header(path)); }
+  //! \param name name to header file
+  void insert(std::pair<std::string>, std::string> header) { m_headers.push_back(Header(header.first, header.second)); }
   //! inserts Header
   //! \param header
   void insert(Header header) { m_headers.push_back(header); }

--- a/include/yacx/util.hpp
+++ b/include/yacx/util.hpp
@@ -14,8 +14,8 @@
 
 namespace yacx {
 
-void debug(const std::string &message);
-
+//! loads the contents of a file as a string
+//! \param path path relative to the root of this project
 std::string load(const std::string &path);
 
 template <typename T> std::string type_of(const T &variable);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,9 +2,14 @@
 
 #include <string>
 #include <vector>
+#include <filesystem>
 
-std::string yacx::load(const std::string &path) {
-  std::ifstream file(path);
+std::string yacx::load(const std::filesystem::path &path) {
+  const std::filesystem::path current_file = __FILE__;
+  const auto current_dir = current_file.parent_path();
+  const auto absolute_path = current_dir + "../" + path
+
+  std::ifstream file(absolute_path);
   return std::string((std::istreambuf_iterator<char>(file)),
                      std::istreambuf_iterator<char>());
 }

--- a/test/test_headers.cpp
+++ b/test/test_headers.cpp
@@ -7,32 +7,32 @@
 using yacx::Headers, yacx::Header;
 
 TEST_CASE("Header can be constructed", "[yacx::header]") {
-  Header header("test_pixel.hpp");
   std::string content{"typedef struct {\n"
                       "  unsigned char r;\n"
                       "  unsigned char g;\n"
                       "  unsigned char b;\n"
                       "} Pixel;\n"};
+  Header header("test_pixel.hpp", content);
 
   REQUIRE(std::string{header.name()} == std::string{"test_pixel.hpp"});
   REQUIRE(std::string{header.content()} == content);
 }
 
 TEST_CASE("Headers can be constructed", "[yacx::headers]") {
-  Header header0("test_pixel.hpp");
   std::string content0{"typedef struct {\n"
                        "  unsigned char r;\n"
                        "  unsigned char g;\n"
                        "  unsigned char b;\n"
                        "} Pixel;\n"};
-  Header header1("test_header1.hpp");
+  Header header0("test_pixel.hpp", content1);
   std::string content1{"typedef struct {\n"
                        "  int x;\n"
                        "} header1;\n"};
-  Header header2("test_header2.hpp");
+  Header header1("test_header1.hpp", content1);
   std::string content2{"typedef struct {\n"
                        "  int y;\n"
                        "} header2;\n"};
+  Header header2("test_header2.hpp", content2);
 
   SECTION("constructed from header") {
     Headers headers{header0, header1, header2};
@@ -45,7 +45,9 @@ TEST_CASE("Headers can be constructed", "[yacx::headers]") {
     REQUIRE(std::string{headers.content()[0]} == content2);
   }
   SECTION("constructed from path") {
-    Headers headers{"test_pixel.hpp", "test_header1.hpp", "test_header2.hpp"};
+    Headers headers{std::make_pair(header0, content0), 
+      std::make_pair(header1, content1), 
+      std::make_pair(header2, content2)};
     REQUIRE(headers.numHeaders() == 3);
     REQUIRE(std::string{headers.names()[2]} == std::string{"test_pixel.hpp"});
     REQUIRE(std::string{headers.names()[1]} == std::string{"test_header1.hpp"});
@@ -57,9 +59,9 @@ TEST_CASE("Headers can be constructed", "[yacx::headers]") {
   SECTION("empty constructor, but inserted headers") {
     Headers headers{};
     REQUIRE(headers.numHeaders() == 0);
-    headers.insert("test_pixel.hpp");
+    headers.insert(std::make_pair(header0, content0));
     REQUIRE(headers.numHeaders() == 1);
-    headers.insert(header1);
+    headers.insert(std::make_pair(header1, content1));
     REQUIRE(headers.numHeaders() == 2);
     REQUIRE(std::string{headers.names()[0]} == std::string{"test_pixel.hpp"});
     REQUIRE(std::string{headers.names()[1]} == std::string{"test_header1.hpp"});


### PR DESCRIPTION
!fixes #70 
!fixes #72 

really wish I knew how to use constexpr like at all: https://github.com/ZerataX/yacx/blob/447ddb3e8392668b9a3bd29cbba2d33316ba7b6e/include/yacx/Headers.hpp#L21
if this was constexpr it would make it really clear that using e.g. `load` is a bad idea, but I have no clue how. If no one knows, just move this to a new issue

probably a neater way to check if both sides of the pair are castable to string
https://github.com/ZerataX/yacx/blob/447ddb3e8392668b9a3bd29cbba2d33316ba7b6e/include/yacx/Headers.hpp#L37-L43

maybe even by using https://github.com/ZerataX/yacx/blob/master/include/yacx/util.hpp#L23-L29

Still can't test anything :/